### PR TITLE
algebra: authenticated-poly: Implement shared polynomial floor division

### DIFF
--- a/src/algebra/poly/poly.rs
+++ b/src/algebra/poly/poly.rs
@@ -126,7 +126,7 @@ impl<C: CurveGroup> DensePolynomialResult<C> {
                 // f * f^{-1}(x) = 1 \in F[x] / (x^t)
                 let self_constant_coeff = self_poly.coeffs[0];
                 let inverse_constant_coeff = inverse_poly.coeffs[0];
-                let leading_coeff_inv = (self_constant_coeff * inverse_constant_coeff)
+                let constant_coeff_inv = (self_constant_coeff * inverse_constant_coeff)
                     .inverse()
                     .unwrap();
 
@@ -134,7 +134,7 @@ impl<C: CurveGroup> DensePolynomialResult<C> {
                     .coeffs
                     .into_iter()
                     .take(n_result_coeffs)
-                    .map(|c| c * leading_coeff_inv)
+                    .map(|c| c * constant_coeff_inv)
                     .map(Scalar::new)
                     .map(ResultValue::Scalar)
                     .collect_vec()
@@ -148,6 +148,7 @@ impl<C: CurveGroup> DensePolynomialResult<C> {
     ///
     /// I.e. for a(x), b(x) as input, we compute f(x), g(x) such that:
     ///     f(x) * a(x) + g(x) * b(x) = gcd(a, b)
+    /// This is done using the extended Euclidean method
     fn compute_bezout_polynomials(
         a: &DensePolynomial<C::ScalarField>,
         b: &DensePolynomial<C::ScalarField>,

--- a/src/algebra/scalar/authenticated_scalar.rs
+++ b/src/algebra/scalar/authenticated_scalar.rs
@@ -190,7 +190,6 @@ impl<C: CurveGroup> AuthenticatedScalarResult<C> {
         //      m_i^-1 * r_i = (x_i^-1 * r_i^-1) * r_i = x_i^-1
         AuthenticatedScalarResult::batch_mul_public(&shared_scalars, &inverted_openings)
     }
-    // Compute
 }
 
 /// Opening implementations


### PR DESCRIPTION
### Purpose
This PR implements polynomial floor division between two polynomials that are shared. This is done in a constant round implementation given by [Mohassel and Franklin](https://iacr.org/archive/pkc2006/39580045/39580045.pdf).

To support this, a few other primitives are added:
- Polynomial multiplicative inversion in the quotient ring $\mathbb{F}[x] / (x^n)$
- Shared scalar multiplicative inversion

### Testing
- Unit and integration tests pass
- Added unit tests for all new primitives